### PR TITLE
Typo fixing

### DIFF
--- a/src/pages/intro/acknowledgements.md
+++ b/src/pages/intro/acknowledgements.md
@@ -1,4 +1,4 @@
-## Acknowledgements 
+## Acknowledgements
 
 Thanks to Miles Sabin and my colleagues at [Underscore][link-underscore]
 for their contributions and feedback.

--- a/src/pages/intro/acknowledgements.md
+++ b/src/pages/intro/acknowledgements.md
@@ -1,4 +1,4 @@
-## Acknowledgements
+## Acknowledgments
 
 Thanks to Miles Sabin and my colleagues at [Underscore][link-underscore]
 for their contributions and feedback.

--- a/src/pages/intro/acknowledgements.md
+++ b/src/pages/intro/acknowledgements.md
@@ -1,4 +1,4 @@
-## Acknowledgments
+## Acknowledgements 
 
 Thanks to Miles Sabin and my colleagues at [Underscore][link-underscore]
 for their contributions and feedback.

--- a/src/pages/intro/thisbook.md
+++ b/src/pages/intro/thisbook.md
@@ -16,7 +16,7 @@ We will use CSV encoding as an example,
 but we will write one set of encoders
 that can handle any case class or sealed trait.
 We will also introduce shapeless' `Lazy` type,
-which lets us handle resursive data like lists and trees.
+which lets us handle recursive data like lists and trees.
 
 In Chapter 4 we will introduce `LabelledGeneric`,
 a variant of `Generic` that exposes field and type names

--- a/src/pages/representations/adts.md
+++ b/src/pages/representations/adts.md
@@ -35,12 +35,13 @@ The compiler has complete knowledge of the algebras we define,
 so it can support us in writing complete,
 correctly typed methods involving our types:
 
-```tut:book:silent
+```tut:book
 def area(shape: Shape): Double =
   shape match {
     case Rectangle(w, h) => w * h
     case Circle(r)       => math.Pi * r * r
   }
+```
 
 ```tut:book
 area(rect)

--- a/src/pages/representations/products.md
+++ b/src/pages/representations/products.md
@@ -1,7 +1,7 @@
 ## Generic product encodings
 
 In the previous section we introduced tuples
-as a generic representation pf products.
+as a generic representation of products.
 Unfortunately, Scala's built-in tuples have a couple of disadvantages
 that make them unsuitable for shapeless' purposes:
 
@@ -109,8 +109,9 @@ val iceCream2: IceCream =
 If two ADTs have the same `Repr`,
 we can convert back and forth between them using their `Generics`:
 
-```tut:book:silent
+```tut:book
 case class Employee(name: String, number: Int, manager: Boolean)
+```
 
 ```tut:book
 // Create an employee from an ice cream:

--- a/src/pages/type-level-programming/dependent-functions.md
+++ b/src/pages/type-level-programming/dependent-functions.md
@@ -85,6 +85,7 @@ and letting the compiler unify them with appropriate types:
 ```tut:book:invisible
 case class Vec(x: Int, y: Int)
 case class Rect(origin: Vec, extent: Vec)
+```
 
 ```tut:book:silent
 def lastField[A, Repr <: HList](input: A)(


### PR DESCRIPTION
Yo @davegurnell 

This PR fixes a few typos and code layout problems I spotted when reading the PDF version of the text.

In addition I found these phrases a bit odd:

> the only limitation to has been ADTs

(at the end of https://github.com/davegurnell/shapeless-guide/blob/develop/src/pages/generic/type-classes.md)

> If can tag `number` using `asInstanceOf`

(in https://github.com/davegurnell/shapeless-guide/blob/develop/src/pages/labelled-generic/literal-types.md)

> The names exposed by `LabelledGeneric` are encoded at as type-level tags, 

(in https://github.com/davegurnell/shapeless-guide/blob/develop/src/pages/labelled-generic/summary.md)
